### PR TITLE
分からなさすぎてラジコンになってた

### DIFF
--- a/data/adv/advancements/killed_zombie.json
+++ b/data/adv/advancements/killed_zombie.json
@@ -1,0 +1,21 @@
+{
+    "criteria": {
+        "requirement": {
+          "trigger": "minecraft:player_killed_entity",
+          "conditions": {
+            "entity": [
+              {
+                "condition": "minecraft:entity_properties",
+                "entity": "this",
+                "predicate": {
+                  "type": "#zombie"
+                }
+              }
+            ]
+          }
+        }
+      },
+    "rewards": {
+        "function": "sys:repeat/killed_zombie_spawn"
+    }
+}

--- a/data/sys/functions/install/buildup.mcfunction
+++ b/data/sys/functions/install/buildup.mcfunction
@@ -58,3 +58,7 @@
 # 乱数生成用
     # iruru.rngスコアを4に設定
         scoreboard players set #4 iruru.rng 4
+
+    # 小ゾンビ乱数用
+        scoreboard objectives add iruru.z_rnd dummy
+        scoreboard players set #100 iruru.z_rnd 100

--- a/data/sys/functions/repeat/killed_zombie_spawn.mcfunction
+++ b/data/sys/functions/repeat/killed_zombie_spawn.mcfunction
@@ -1,0 +1,30 @@
+#> sys:repeat/killed_zombie_spawn
+
+# ゾンビを殺した際に確率で周りに子ゾンビをスポーンさせる
+
+#実績削除
+    advancement revoke @s only adv:killed_zombie
+    
+    #乱数生成
+    summon area_effect_cloud ~ ~ ~ {Tags:["RND"]}
+    execute store result score @s iruru.z_rnd run data get entity @e[tag=RND,distance=..0.01,limit=1] UUID[0]
+    
+    scoreboard players operation @s iruru.z_rnd %= #100 iruru.z_rnd
+    
+#20~23日
+    #25%で子ゾン1
+    execute if score $day iruru.daycount matches 20..23 if score @s iruru.z_rnd matches ..15 run summon zombie ^ ^3 ^5 {IsBaby:1b}
+
+#24~27日
+    #5%で子ゾン1
+    #3%で子ゾン+1
+    execute if score $day iruru.daycount matches 24..27 if score @s iruru.z_rnd matches ..5 run summon zombie ^ ^3 ^5 {IsBaby:1b}
+    execute if score $day iruru.daycount matches 24..27 if score @s iruru.z_rnd matches ..3 run summon zombie ^1 ^3 ^5 {IsBaby:1b}
+
+#28~30日
+    #25%で子ゾン1
+    #15%で子ゾン+1
+    #8%で子ゾン+1
+    execute if score $day iruru.daycount matches 28..30 if score @s iruru.z_rnd matches ..15 run summon zombie ^ ^3 ^5 {IsBaby:1b}
+    execute if score $day iruru.daycount matches 28..30 if score @s iruru.z_rnd matches ..10 run summon zombie ^-1 ^3 ^5 {IsBaby:1b}
+    execute if score $day iruru.daycount matches 28..30 if score @s iruru.z_rnd matches ..8 run summon zombie ^1 ^3 ^7 {IsBaby:1b}


### PR DESCRIPTION
- 日が経ったときにゾンビを倒した際、確率で子ぞんをスポーン

1. スポーン位置は倒したプレイヤーの座標を参照。(倒したゾンビの座標取得できませんでした…)
2. 20~23,24~27,28~30間隔で確率変化(テストしてみたけど、マルチでやったらもしかしたら高いかも)
3. 乱数は#100 z_rndで取得
4. 一応スコアボードで値は監視はしてたけど、100％テストやった後はテストしてないからもしかしたら動かない可能性
5. 倒したゾンビのタイプは指定してないから小ゾンから小ゾンが出てくる確変にたまに入ります